### PR TITLE
Add status effect functionality

### DIFF
--- a/src/routes/combat/combat.js
+++ b/src/routes/combat/combat.js
@@ -5,7 +5,6 @@ import {
   Checkbox,
   Divider,
   FormControlLabel,
-  FormGroup,
   Grid,
   Skeleton,
   TextField,
@@ -83,9 +82,7 @@ function AuthCombat({ user }) {
   });
 
   console.debug(npcs);
-  console.log(
-    npcs
-  )
+
 
   return (
     <Grid container sx={{ mt: 2 }}>
@@ -117,6 +114,17 @@ function AuthCombat({ user }) {
 function Npc({ npc }) {
   const [hp, setHp] = useState(calcHP(npc));
   const [mp, setMp] = useState(calcMP(npc));
+  const [attributes, setAttributes] = useState(npc.attributes);
+  const [statusEffects, setStatusEffects] = useState({
+    slow: false,
+    dazed: false,
+    weak: false,
+    shaken: false,
+    enraged: false,
+    poisoned: false
+  })
+
+  const originalAttributes = npc.attributes;
 
   const changeHp = (value) => {
     return () => {
@@ -128,6 +136,92 @@ function Npc({ npc }) {
       setMp(mp + value);
     };
   };
+
+  const decreaseAttribute = (attribute = 0, min = 6) => {
+    return attribute <= min ? min : attribute - 2;
+  }
+
+  const increaseAttribute = (attribute = 0, max = 12) => {
+    return attribute >= max ? max : attribute + 2;
+  }
+
+  const toggleStatus = (status = '', hasStatus = false) => {
+    switch (status) {
+      case 'slow':
+
+        setStatusEffects(s => ({
+          ...s,
+          slow: hasStatus
+        }));
+        setAttributes(s => ({
+          ...s,
+          dexterity: hasStatus ? decreaseAttribute(s.dexterity) : increaseAttribute(s.dexterity, originalAttributes.dexterity)
+        }));
+        break;
+      case 'dazed':
+
+        setStatusEffects(s => ({
+          ...s,
+          dazed: hasStatus
+        }))
+        setAttributes(s => ({
+          ...s,
+          insight: hasStatus ? decreaseAttribute(s.insight) : increaseAttribute(s.insight, originalAttributes.insight)
+        }));
+        break;
+      case 'weak':
+
+        setStatusEffects(s => ({
+          ...s,
+          weak: hasStatus
+        }))
+        setAttributes(s => ({
+          ...s,
+          might: hasStatus ? decreaseAttribute(s.might) : increaseAttribute(s.might, originalAttributes.might)
+        }));
+        break;
+      case 'shaken':
+
+        setStatusEffects(s => ({
+          ...s,
+          shaken: hasStatus
+        }))
+        setAttributes(s => ({
+          ...s,
+          will: hasStatus ? decreaseAttribute(s.will) : increaseAttribute(s.will, originalAttributes.will)
+        }));
+        break;
+      case 'enraged':
+
+        setStatusEffects(s => ({
+          ...s,
+          enraged: hasStatus
+        }))
+        setAttributes(s => ({
+          ...s,
+          dexterity: hasStatus ? decreaseAttribute(s.dexterity) : increaseAttribute(s.dexterity, originalAttributes.dexterity),
+          insight: hasStatus ? decreaseAttribute(s.insight) : increaseAttribute(s.insight, originalAttributes.insight)
+        }));
+        break;
+      case 'poisoned':
+
+        setStatusEffects(s => ({
+          ...s,
+          poisoned: hasStatus
+        }))
+        setAttributes(s => ({
+          ...s,
+          might: hasStatus ? decreaseAttribute(s.might) : increaseAttribute(s.might, originalAttributes.might),
+          will: hasStatus ? decreaseAttribute(s.will) : increaseAttribute(s.will, originalAttributes.will)
+        }));
+        break;
+      default:
+        break;
+    }
+  }
+
+
+
 
   const crisis = hp < calcHP(npc) / 2;
 
@@ -185,49 +279,117 @@ function Npc({ npc }) {
               <Button onClick={changeMp(+20)}>+20</Button>
             </ButtonGroup>
           </Grid>
-          <Grid item xs={12}>
-            <FormGroup aria-label="position" row>
+          <Grid item container xs={12}>
+            <Grid item xs>
+              <Typography variant="h5">
+                DEX: d{attributes.dexterity}
+              </Typography>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="h5">
+                INS: d{attributes.insight}
+              </Typography>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="h5">
+                MIG: d{attributes.might}
+              </Typography>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="h5">
+                WIL: d{attributes.will}
+              </Typography>
+            </Grid>
+          </Grid>
+          <Grid item container xs={12}>
+            <Grid item xs>
               <FormControlLabel
                 value="slow"
-                control={<Checkbox />}
+                control={<Checkbox
+                  onClick={({ target: { value, checked } }) => {
+
+                    toggleStatus(value, checked)
+
+                  }}
+                />}
                 label="Slow"
                 labelPlacement="top"
+
               />
+            </Grid>
+            <Grid item xs>
               <FormControlLabel
                 value="dazed"
-                control={<Checkbox />}
+                control={<Checkbox
+                  onClick={({ target: { value, checked } }) => {
+
+                    toggleStatus(value, checked)
+
+                  }}
+                />}
                 label="Dazed"
                 labelPlacement="top"
               />
+            </Grid>
+            <Grid item xs>
               <FormControlLabel
                 value="weak"
-                control={<Checkbox />}
+                control={<Checkbox
+                  onClick={({ target: { value, checked } }) => {
+
+                    toggleStatus(value, checked)
+
+                  }}
+                />}
                 label="Weak"
                 labelPlacement="top"
               />
+            </Grid>
+            <Grid item xs>
               <FormControlLabel
                 value="shaken"
-                control={<Checkbox />}
+                control={<Checkbox
+                  onClick={({ target: { value, checked } }) => {
+
+                    toggleStatus(value, checked)
+
+                  }}
+                />}
                 label="Shaken"
                 labelPlacement="top"
+
               />
-            </FormGroup>
+            </Grid>
           </Grid>
-          <Grid item xs={12}>
-            <FormGroup aria-label="position" row>
+          <Grid item container xs={12}>
+            <Grid item xs display='flex' justifyContent='center'>
               <FormControlLabel
                 value="enraged"
-                control={<Checkbox />}
+                control={<Checkbox
+                  onClick={({ target: { value, checked } }) => {
+
+                    toggleStatus(value, checked)
+
+                  }}
+                />}
                 label="Enraged"
                 labelPlacement="top"
               />
+            </Grid>
+            <Grid item xs display='flex' justifyContent='center'>
               <FormControlLabel
                 value="poisoned"
-                control={<Checkbox />}
-                label="Poisoned"
+                control={<Checkbox
+                  onClick={({ target: { value, checked } }) => {
+
+                    toggleStatus(value, checked)
+
+                  }}
+                />}
+                label="poisoned"
                 labelPlacement="top"
               />
-            </FormGroup>
+            </Grid>
           </Grid>
           <Grid item flex="1"></Grid>
         </Grid>

--- a/src/routes/combat/combat.js
+++ b/src/routes/combat/combat.js
@@ -83,6 +83,9 @@ function AuthCombat({ user }) {
   });
 
   console.debug(npcs);
+  console.log(
+    npcs
+  )
 
   return (
     <Grid container sx={{ mt: 2 }}>

--- a/src/routes/combat/combat.js
+++ b/src/routes/combat/combat.js
@@ -20,6 +20,7 @@ import { auth, firestore } from "../../firebase";
 import Layout from "../../components/Layout";
 import NpcPretty from "../../components/npc/Pretty";
 import { calcHP, calcMP } from "../../libs/npcs";
+import { useEffect } from "react";
 
 export default function Combat() {
   const [user, loading, error] = useAuthState(auth);
@@ -137,83 +138,66 @@ function Npc({ npc }) {
     };
   };
 
-  const decreaseAttribute = (attribute = 0, min = 6) => {
-    return attribute <= min ? min : attribute - 2;
+  const adjustAttribute = (attribute = 0, amount = 0, min = 6) => {
+    return attribute + amount <= min ? min : attribute + amount
   }
 
-  const increaseAttribute = (attribute = 0, max = 12) => {
-    return attribute >= max ? max : attribute + 2;
-  }
+  useEffect(() => {
+    let {
+      slow,
+      dazed,
+      weak,
+      shaken,
+      enraged,
+      poisoned
+    } = statusEffects
+
+    setAttributes({
+      dexterity: enraged && slow ? adjustAttribute(originalAttributes.dexterity, -4) : enraged || slow ? adjustAttribute(originalAttributes.dexterity, -2) : originalAttributes.dexterity,
+      insight: enraged && dazed ? adjustAttribute(originalAttributes.insight, -4) : enraged || dazed ? adjustAttribute(originalAttributes.insight, -2) : originalAttributes.insight,
+      might: poisoned && weak ? adjustAttribute(originalAttributes.might, -4) : poisoned || weak ? adjustAttribute(originalAttributes.might, -2) : originalAttributes.might,
+      will: poisoned && shaken ? adjustAttribute(originalAttributes.will, -4) : poisoned || shaken ? adjustAttribute(originalAttributes.will, -2) : originalAttributes.will
+    });
+  }, [statusEffects]);
+
 
   const toggleStatus = (status = '', hasStatus = false) => {
     switch (status) {
       case 'slow':
-
         setStatusEffects(s => ({
           ...s,
           slow: hasStatus
         }));
-        setAttributes(s => ({
-          ...s,
-          dexterity: hasStatus ? decreaseAttribute(s.dexterity) : increaseAttribute(s.dexterity, originalAttributes.dexterity)
-        }));
         break;
       case 'dazed':
-
         setStatusEffects(s => ({
           ...s,
           dazed: hasStatus
         }))
-        setAttributes(s => ({
-          ...s,
-          insight: hasStatus ? decreaseAttribute(s.insight) : increaseAttribute(s.insight, originalAttributes.insight)
-        }));
         break;
       case 'weak':
-
         setStatusEffects(s => ({
           ...s,
           weak: hasStatus
         }))
-        setAttributes(s => ({
-          ...s,
-          might: hasStatus ? decreaseAttribute(s.might) : increaseAttribute(s.might, originalAttributes.might)
-        }));
         break;
       case 'shaken':
-
         setStatusEffects(s => ({
           ...s,
           shaken: hasStatus
         }))
-        setAttributes(s => ({
-          ...s,
-          will: hasStatus ? decreaseAttribute(s.will) : increaseAttribute(s.will, originalAttributes.will)
-        }));
         break;
       case 'enraged':
-
         setStatusEffects(s => ({
           ...s,
           enraged: hasStatus
         }))
-        setAttributes(s => ({
-          ...s,
-          dexterity: hasStatus ? decreaseAttribute(s.dexterity) : increaseAttribute(s.dexterity, originalAttributes.dexterity),
-          insight: hasStatus ? decreaseAttribute(s.insight) : increaseAttribute(s.insight, originalAttributes.insight)
-        }));
         break;
       case 'poisoned':
-
         setStatusEffects(s => ({
           ...s,
           poisoned: hasStatus
         }))
-        setAttributes(s => ({
-          ...s,
-          might: hasStatus ? decreaseAttribute(s.might) : increaseAttribute(s.might, originalAttributes.might),
-          will: hasStatus ? decreaseAttribute(s.will) : increaseAttribute(s.will, originalAttributes.will)
-        }));
         break;
       default:
         break;
@@ -307,14 +291,11 @@ function Npc({ npc }) {
                 value="slow"
                 control={<Checkbox
                   onClick={({ target: { value, checked } }) => {
-
                     toggleStatus(value, checked)
-
                   }}
                 />}
                 label="Slow"
                 labelPlacement="top"
-
               />
             </Grid>
             <Grid item xs>
@@ -322,9 +303,7 @@ function Npc({ npc }) {
                 value="dazed"
                 control={<Checkbox
                   onClick={({ target: { value, checked } }) => {
-
                     toggleStatus(value, checked)
-
                   }}
                 />}
                 label="Dazed"
@@ -336,9 +315,7 @@ function Npc({ npc }) {
                 value="weak"
                 control={<Checkbox
                   onClick={({ target: { value, checked } }) => {
-
                     toggleStatus(value, checked)
-
                   }}
                 />}
                 label="Weak"
@@ -350,14 +327,11 @@ function Npc({ npc }) {
                 value="shaken"
                 control={<Checkbox
                   onClick={({ target: { value, checked } }) => {
-
                     toggleStatus(value, checked)
-
                   }}
                 />}
                 label="Shaken"
                 labelPlacement="top"
-
               />
             </Grid>
           </Grid>
@@ -367,9 +341,7 @@ function Npc({ npc }) {
                 value="enraged"
                 control={<Checkbox
                   onClick={({ target: { value, checked } }) => {
-
                     toggleStatus(value, checked)
-
                   }}
                 />}
                 label="Enraged"
@@ -381,9 +353,7 @@ function Npc({ npc }) {
                 value="poisoned"
                 control={<Checkbox
                   onClick={({ target: { value, checked } }) => {
-
                     toggleStatus(value, checked)
-
                   }}
                 />}
                 label="poisoned"

--- a/src/routes/combat/combat.js
+++ b/src/routes/combat/combat.js
@@ -84,7 +84,6 @@ function AuthCombat({ user }) {
 
   console.debug(npcs);
 
-
   return (
     <Grid container sx={{ mt: 2 }}>
       {npcs?.map((npc) => {
@@ -122,8 +121,8 @@ function Npc({ npc }) {
     weak: false,
     shaken: false,
     enraged: false,
-    poisoned: false
-  })
+    poisoned: false,
+  });
 
   const originalAttributes = npc.attributes;
 
@@ -139,73 +138,82 @@ function Npc({ npc }) {
   };
 
   const adjustAttribute = (attribute = 0, amount = 0, min = 6) => {
-    return attribute + amount <= min ? min : attribute + amount
-  }
+    return attribute + amount <= min ? min : attribute + amount;
+  };
 
   useEffect(() => {
-    let {
-      slow,
-      dazed,
-      weak,
-      shaken,
-      enraged,
-      poisoned
-    } = statusEffects
+    let { slow, dazed, weak, shaken, enraged, poisoned } = statusEffects;
 
     setAttributes({
-      dexterity: enraged && slow ? adjustAttribute(originalAttributes.dexterity, -4) : enraged || slow ? adjustAttribute(originalAttributes.dexterity, -2) : originalAttributes.dexterity,
-      insight: enraged && dazed ? adjustAttribute(originalAttributes.insight, -4) : enraged || dazed ? adjustAttribute(originalAttributes.insight, -2) : originalAttributes.insight,
-      might: poisoned && weak ? adjustAttribute(originalAttributes.might, -4) : poisoned || weak ? adjustAttribute(originalAttributes.might, -2) : originalAttributes.might,
-      will: poisoned && shaken ? adjustAttribute(originalAttributes.will, -4) : poisoned || shaken ? adjustAttribute(originalAttributes.will, -2) : originalAttributes.will
+      dexterity:
+        enraged && slow
+          ? adjustAttribute(originalAttributes.dexterity, -4)
+          : enraged || slow
+          ? adjustAttribute(originalAttributes.dexterity, -2)
+          : originalAttributes.dexterity,
+      insight:
+        enraged && dazed
+          ? adjustAttribute(originalAttributes.insight, -4)
+          : enraged || dazed
+          ? adjustAttribute(originalAttributes.insight, -2)
+          : originalAttributes.insight,
+      might:
+        poisoned && weak
+          ? adjustAttribute(originalAttributes.might, -4)
+          : poisoned || weak
+          ? adjustAttribute(originalAttributes.might, -2)
+          : originalAttributes.might,
+      will:
+        poisoned && shaken
+          ? adjustAttribute(originalAttributes.will, -4)
+          : poisoned || shaken
+          ? adjustAttribute(originalAttributes.will, -2)
+          : originalAttributes.will,
     });
   }, [statusEffects]);
 
-
-  const toggleStatus = (status = '', hasStatus = false) => {
+  const toggleStatus = (status = "", hasStatus = false) => {
     switch (status) {
-      case 'slow':
-        setStatusEffects(s => ({
+      case "slow":
+        setStatusEffects((s) => ({
           ...s,
-          slow: hasStatus
+          slow: hasStatus,
         }));
         break;
-      case 'dazed':
-        setStatusEffects(s => ({
+      case "dazed":
+        setStatusEffects((s) => ({
           ...s,
-          dazed: hasStatus
-        }))
+          dazed: hasStatus,
+        }));
         break;
-      case 'weak':
-        setStatusEffects(s => ({
+      case "weak":
+        setStatusEffects((s) => ({
           ...s,
-          weak: hasStatus
-        }))
+          weak: hasStatus,
+        }));
         break;
-      case 'shaken':
-        setStatusEffects(s => ({
+      case "shaken":
+        setStatusEffects((s) => ({
           ...s,
-          shaken: hasStatus
-        }))
+          shaken: hasStatus,
+        }));
         break;
-      case 'enraged':
-        setStatusEffects(s => ({
+      case "enraged":
+        setStatusEffects((s) => ({
           ...s,
-          enraged: hasStatus
-        }))
+          enraged: hasStatus,
+        }));
         break;
-      case 'poisoned':
-        setStatusEffects(s => ({
+      case "poisoned":
+        setStatusEffects((s) => ({
           ...s,
-          poisoned: hasStatus
-        }))
+          poisoned: hasStatus,
+        }));
         break;
       default:
         break;
     }
-  }
-
-
-
+  };
 
   const crisis = hp < calcHP(npc) / 2;
 
@@ -265,99 +273,97 @@ function Npc({ npc }) {
           </Grid>
           <Grid item container xs={12}>
             <Grid item xs>
-              <Typography variant="h5">
-                DEX: d{attributes.dexterity}
-              </Typography>
+              <Typography variant="h5">DEX: d{attributes.dexterity}</Typography>
             </Grid>
             <Grid item xs>
-              <Typography variant="h5">
-                INS: d{attributes.insight}
-              </Typography>
+              <Typography variant="h5">INS: d{attributes.insight}</Typography>
             </Grid>
             <Grid item xs>
-              <Typography variant="h5">
-                MIG: d{attributes.might}
-              </Typography>
+              <Typography variant="h5">MIG: d{attributes.might}</Typography>
             </Grid>
             <Grid item xs>
-              <Typography variant="h5">
-                WIL: d{attributes.will}
-              </Typography>
+              <Typography variant="h5">WIL: d{attributes.will}</Typography>
             </Grid>
           </Grid>
           <Grid item container xs={12}>
             <Grid item xs>
               <FormControlLabel
                 value="slow"
-                control={<Checkbox
-                  onClick={({ target: { value, checked } }) => {
-                    toggleStatus(value, checked)
-                  }}
-                />}
+                control={<Checkbox />}
                 label="Slow"
                 labelPlacement="top"
+                onClick={({ target: { value, checked } }) => {
+                  if (typeof checked === "boolean") {
+                    toggleStatus(value, checked);
+                  }
+                }}
               />
             </Grid>
             <Grid item xs>
               <FormControlLabel
                 value="dazed"
-                control={<Checkbox
-                  onClick={({ target: { value, checked } }) => {
-                    toggleStatus(value, checked)
-                  }}
-                />}
+                control={<Checkbox />}
                 label="Dazed"
                 labelPlacement="top"
+                onClick={({ target: { value, checked } }) => {
+                  if (typeof checked === "boolean") {
+                    toggleStatus(value, checked);
+                  }
+                }}
               />
             </Grid>
             <Grid item xs>
               <FormControlLabel
                 value="weak"
-                control={<Checkbox
-                  onClick={({ target: { value, checked } }) => {
-                    toggleStatus(value, checked)
-                  }}
-                />}
+                control={<Checkbox />}
                 label="Weak"
                 labelPlacement="top"
+                onClick={({ target: { value, checked } }) => {
+                  if (typeof checked === "boolean") {
+                    toggleStatus(value, checked);
+                  }
+                }}
               />
             </Grid>
             <Grid item xs>
               <FormControlLabel
                 value="shaken"
-                control={<Checkbox
-                  onClick={({ target: { value, checked } }) => {
-                    toggleStatus(value, checked)
-                  }}
-                />}
+                control={<Checkbox />}
                 label="Shaken"
                 labelPlacement="top"
+                onClick={({ target: { value, checked } }) => {
+                  if (typeof checked === "boolean") {
+                    toggleStatus(value, checked);
+                  }
+                }}
               />
             </Grid>
           </Grid>
           <Grid item container xs={12}>
-            <Grid item xs display='flex' justifyContent='center'>
+            <Grid item xs display="flex" justifyContent="center">
               <FormControlLabel
                 value="enraged"
-                control={<Checkbox
-                  onClick={({ target: { value, checked } }) => {
-                    toggleStatus(value, checked)
-                  }}
-                />}
+                control={<Checkbox />}
                 label="Enraged"
                 labelPlacement="top"
+                onClick={({ target: { value, checked } }) => {
+                  if (typeof checked === "boolean") {
+                    toggleStatus(value, checked);
+                  }
+                }}
               />
             </Grid>
-            <Grid item xs display='flex' justifyContent='center'>
+            <Grid item xs display="flex" justifyContent="center">
               <FormControlLabel
                 value="poisoned"
-                control={<Checkbox
-                  onClick={({ target: { value, checked } }) => {
-                    toggleStatus(value, checked)
-                  }}
-                />}
-                label="poisoned"
+                control={<Checkbox />}
+                label="Poisoned"
                 labelPlacement="top"
+                onClick={({ target: { value, checked } }) => {
+                  if (typeof checked === "boolean") {
+                    toggleStatus(value, checked);
+                  }
+                }}
               />
             </Grid>
           </Grid>


### PR DESCRIPTION
- Displays the current attribute die sizes
- Status effect toggles are aligned with the corresponding attribute/s affected
- Toggling status effect checkboxes adjusts the die sizes up to a minimum of 6 (left adjustable in case of future changes)