### PR TITLE
feat: no damage type base attack

### DIFF
--- a/src/components/Bracket.js
+++ b/src/components/Bracket.js
@@ -2,7 +2,7 @@ import { Typography } from "@mui/material";
 
 export function OpenBracket() {
   return (
-    <Typography component="span" sx={{ ml: -1, mr: 0.3 }}>
+    <Typography component="span" sx={{ ml: -1, mr: 0 }}>
       【
     </Typography>
   );

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -17,7 +17,7 @@ const TagList = ({ npc, setNpc }) => {
   const maxTags = 5; // Maximum tag count
   const maxTagLength = 50; // Maximum tag length
 
-  console.log(npc.tags);
+  //console.log(npc.tags);
 
   // Function to handle deletion of a tag
   const handleDelete = (i) => {

--- a/src/components/npc/EditAttacks.js
+++ b/src/components/npc/EditAttacks.js
@@ -195,6 +195,9 @@ function EditAttack({ attack, setAttack, removeAttack, i }) {
                 </MenuItem>
               );
             })}
+            <MenuItem value={"nodmg"}>
+              no damage
+            </MenuItem>
           </Select>
         </FormControl>
       </Grid>

--- a/src/components/npc/Pretty.js
+++ b/src/components/npc/Pretty.js
@@ -31,7 +31,10 @@ import EditableImage from "../EditableImage";
 import { ArrowDropDown } from "@mui/icons-material";
 import { useTranslate, t } from "../../translation/translate";
 
-function NpcPretty({ npc, study, collapse, includeImage, onClick = () => { } }, ref) {
+function NpcPretty(
+  { npc, study, collapse, includeImage, onClick = () => {} },
+  ref
+) {
   const { t } = useTranslate();
   return (
     <Card>
@@ -139,7 +142,7 @@ function Header({ npc, includeImage }) {
           </Typography>
         </Grid>
       </Grid>
-      <Box sx={{ display: 'flex' }}>
+      <Box sx={{ display: "flex" }}>
         {/* EditableImage */}
         {includeImage && (
           <Box
@@ -150,7 +153,7 @@ function Header({ npc, includeImage }) {
               background: "white",
               border: "1px solid #684268",
               borderTop: "none",
-              overflow: "hidden"
+              overflow: "hidden",
             }}
           >
             <EditableImage size={120} />
@@ -188,7 +191,10 @@ function Header({ npc, includeImage }) {
             }}
           >
             <Typography>
-              <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+              <StyledMarkdown
+                allowedElements={["strong", "em"]}
+                unwrapDisallowed={true}
+              >
                 {npc.description}
               </StyledMarkdown>
             </Typography>
@@ -487,28 +493,38 @@ function Attacks({ npc }) {
                 <strong>{attack.name}</strong> <Diamond />{" "}
                 <strong>
                   <OpenBracket />
-                  {attributes[attack.attr1].shortcaps}+
+                  {attributes[attack.attr1].shortcaps} {" + "}
                   {attributes[attack.attr2].shortcaps}
                   <CloseBracket />
                   {calcPrecision(attack, npc) > 0 &&
-                    `+${calcPrecision(attack, npc)}`}
-                  <Diamond /> <OpenBracket />
-                  {t("HR")} + {calcDamage(attack, npc)}
-                  <CloseBracket />
-                </strong>{" "}
-                {attack.type === "physical" ? (
-                  <span>
-                    <ReactMarkdown allowedElements={["strong"]} unwrapDisallowed={true}>
-                      {t(damageTypeLabels[attack.type])}
-                    </ReactMarkdown>
-                  </span>
-                ) : (
+                    `+${calcPrecision(attack, npc)}`}{" "}
+                </strong>
+                {attack.type !== "nodmg" && (
                   <>
-                    <span style={{ textTransform: "lowercase" }}>
-                      <ReactMarkdown allowedElements={["strong"]} unwrapDisallowed={true}>
-                        {t(damageTypeLabels[attack.type])}
-                      </ReactMarkdown>
-                    </span>
+                    <strong>
+                      <Diamond /> <OpenBracket />
+                      {t("HR") + " + " + calcDamage(attack, npc)}
+                      <CloseBracket />{" "}
+                    </strong>
+                    {attack.type === "physical" ? (
+                      <span>
+                        <ReactMarkdown
+                          allowedElements={["strong"]}
+                          unwrapDisallowed={true}
+                        >
+                          {t(damageTypeLabels[attack.type])}
+                        </ReactMarkdown>
+                      </span>
+                    ) : (
+                      <span style={{ textTransform: "lowercase" }}>
+                        <ReactMarkdown
+                          allowedElements={["strong"]}
+                          unwrapDisallowed={true}
+                        >
+                          {t(damageTypeLabels[attack.type])}
+                        </ReactMarkdown>
+                      </span>
+                    )}
                   </>
                 )}{" "}
                 {attack.special?.map((effect, i) => {
@@ -516,7 +532,10 @@ function Attacks({ npc }) {
                     <Typography component="span" key={i}>
                       {" "}
                       -{" "}
-                      <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                      <StyledMarkdown
+                        allowedElements={["strong", "em"]}
+                        unwrapDisallowed={true}
+                      >
                         {effect}
                       </StyledMarkdown>{" "}
                     </Typography>
@@ -525,7 +544,10 @@ function Attacks({ npc }) {
                 {typeof myVar === "string" ||
                   (attack.special instanceof String && (
                     <Typography component="span" key={i}>
-                      <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                      <StyledMarkdown
+                        allowedElements={["strong", "em"]}
+                        unwrapDisallowed={true}
+                      >
                         {attack.special}
                       </StyledMarkdown>
                     </Typography>
@@ -556,25 +578,31 @@ function Attacks({ npc }) {
                 <Diamond />{" "}
                 <strong>
                   <OpenBracket />
-                  {attributes[attack.weapon.att1].shortcaps}+
+                  {attributes[attack.weapon.att1].shortcaps}{" + "}
                   {attributes[attack.weapon.att2].shortcaps}
                   <CloseBracket />
                   {calcPrecision(attack, npc) > 0 &&
-                    `+${calcPrecision(attack, npc)}`}
+                    `+${calcPrecision(attack, npc)}`}{" "}
                   <Diamond /> <OpenBracket />
                   {t("HR")} + {calcDamage(attack, npc)}
                   <CloseBracket />
                 </strong>{" "}
                 {attack.weapon.type === "physical" ? (
                   <span>
-                    <ReactMarkdown allowedElements={["strong"]} unwrapDisallowed={true}>
+                    <ReactMarkdown
+                      allowedElements={["strong"]}
+                      unwrapDisallowed={true}
+                    >
                       {t(damageTypeLabels[attack.weapon.type])}
                     </ReactMarkdown>
                   </span>
                 ) : (
                   <>
                     <span style={{ textTransform: "lowercase" }}>
-                      <ReactMarkdown allowedElements={["strong"]} unwrapDisallowed={true}>
+                      <ReactMarkdown
+                        allowedElements={["strong"]}
+                        unwrapDisallowed={true}
+                      >
                         {t(damageTypeLabels[attack.weapon.type])}
                       </ReactMarkdown>
                     </span>
@@ -585,7 +613,10 @@ function Attacks({ npc }) {
                     <Typography component="span" key={i}>
                       {" "}
                       -{" "}
-                      <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                      <StyledMarkdown
+                        allowedElements={["strong", "em"]}
+                        unwrapDisallowed={true}
+                      >
                         {effect}
                       </StyledMarkdown>{" "}
                     </Typography>
@@ -648,10 +679,10 @@ function Spells({ npc }) {
                   {spell.type === "offensive" && (
                     <>
                       <OpenBracket />
-                      {attributes[spell.attr1].shortcaps}+
+                      {attributes[spell.attr1].shortcaps}{" + "}
                       {attributes[spell.attr2].shortcaps}
                       <CloseBracket />
-                      {calcMagic(npc) > 0 && `+${calcMagic(npc)}`}
+                      {calcMagic(npc) > 0 && `+${calcMagic(npc)}`}{" "}
                       <Diamond />
                     </>
                   )}{" "}
@@ -660,7 +691,10 @@ function Spells({ npc }) {
                 </strong>
                 <br />
                 <Typography component="span" key={i}>
-                  <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                  <StyledMarkdown
+                    allowedElements={["strong", "em"]}
+                    unwrapDisallowed={true}
+                  >
                     {spell.effect}
                   </StyledMarkdown>{" "}
                 </Typography>
@@ -748,7 +782,10 @@ function Special({ npc }) {
                 <span style={{ display: "inline" }}>
                   <strong>{special.name}</strong> <Diamond />{" "}
                 </span>
-                <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                <StyledMarkdown
+                  allowedElements={["strong", "em"]}
+                  unwrapDisallowed={true}
+                >
                   {special.effect}
                 </StyledMarkdown>
               </Typography>
@@ -813,7 +850,10 @@ function Actions({ npc }) {
             <Grid item xs={11} sx={{ px: 1, py: 0.5 }}>
               <Typography>
                 <strong>{actions.name}</strong> <Diamond />{" "}
-                <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                <StyledMarkdown
+                  allowedElements={["strong", "em"]}
+                  unwrapDisallowed={true}
+                >
                   {actions.effect}
                 </StyledMarkdown>
               </Typography>
@@ -878,7 +918,10 @@ function Notes({ npc }) {
             <Grid item xs={11} sx={{ pl: 1, pr: 5, py: 1 }}>
               <Typography>
                 <strong>{notes.name}</strong> <Diamond />{" "}
-                <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                <StyledMarkdown
+                  allowedElements={["strong", "em"]}
+                  unwrapDisallowed={true}
+                >
                   {notes.effect}
                 </StyledMarkdown>
               </Typography>
@@ -943,7 +986,10 @@ function RareGear({ npc }) {
             <Grid item xs={11} sx={{ px: 1, py: 0.5 }}>
               <Typography>
                 <strong>{raregear.name}</strong> <Diamond />{" "}
-                <StyledMarkdown allowedElements={["strong", "em"]} unwrapDisallowed={true}>
+                <StyledMarkdown
+                  allowedElements={["strong", "em"]}
+                  unwrapDisallowed={true}
+                >
                   {raregear.effect}
                 </StyledMarkdown>
               </Typography>
@@ -1013,30 +1059,38 @@ function Equip({ npc }) {
         <Grid key={i} item xs={12} sx={{ px: 2, py: 0 }}>
           <Typography>
             <strong>{t("Weapon:")}</strong> {weapon.name}{" "}
-            {weapon.martial && <Martial />}
+            {weapon.martial && <Martial />}{" "}
+            <Diamond /> {weapon.hands === 1
+              ? t("1 handed")
+              : t("2 handed")}{" "}
             <Diamond />{" "}
-            {weapon.hands === 1 ? t("1 handed") : t("2 handed")} <Diamond />{" "}
             <strong>
               {" "}
               <OpenBracket />
-              {attributes[weapon.att1].shortcaps}+
+              {attributes[weapon.att1].shortcaps}{" + "}
               {attributes[weapon.att2].shortcaps}
               <CloseBracket />
-              {weapon.prec > 0 && `+${weapon.prec}`}
+              {weapon.prec > 0 && `+${weapon.prec}`}{" "}
               <Diamond /> <OpenBracket />
-              {t("HR:")} + {weapon.damage}
+              {t("HR")} + {weapon.damage}
               <CloseBracket />
             </strong>{" "}
             {weapon.type === "physical" ? (
               <span>
-                <ReactMarkdown allowedElements={["strong"]} unwrapDisallowed={true}>
+                <ReactMarkdown
+                  allowedElements={["strong"]}
+                  unwrapDisallowed={true}
+                >
                   {t(damageTypeLabels[weapon.type])}
                 </ReactMarkdown>
               </span>
             ) : (
               <>
                 <span style={{ textTransform: "lowercase" }}>
-                  <ReactMarkdown allowedElements={["strong"]} unwrapDisallowed={true}>
+                  <ReactMarkdown
+                    allowedElements={["strong"]}
+                    unwrapDisallowed={true}
+                  >
                     {t(damageTypeLabels[weapon.type])}
                   </ReactMarkdown>
                 </span>
@@ -1064,7 +1118,7 @@ function Equip({ npc }) {
           )}{" "}
           <Diamond />{" "}
           <strong>
-            {t("M.DEF")} +{npc.armor.mdefbonus}
+            {t("M.DEF")} + {npc.armor.mdefbonus}
           </strong>{" "}
           <Diamond /> {t("Init.")} <strong>{npc.armor.init}</strong> <Diamond />{" "}
           <strong>{npc.armor.cost}</strong> {t("zenit")}
@@ -1088,7 +1142,7 @@ function Equip({ npc }) {
           )}{" "}
           <Diamond />{" "}
           <strong>
-            {t("M.DEF")} +{npc.shield.mdefbonus}
+            {t("M.DEF")} + {npc.shield.mdefbonus}
           </strong>{" "}
           <Diamond /> {t("Init.")} <strong>{npc.shield.init}</strong>{" "}
           <Diamond /> <strong>{npc.shield.cost}</strong> {t("zenit")}
@@ -1099,7 +1153,6 @@ function Equip({ npc }) {
 }
 
 function RenderVillainPhase({ villain, phases, multipart }) {
-
   const getVillainLabel = (villainType) => {
     switch (villainType) {
       case "minor":
@@ -1116,11 +1169,9 @@ function RenderVillainPhase({ villain, phases, multipart }) {
   const phaseString =
     phases && phases >= 1 ? `${t("Phase", true)} ${phases}` : null;
 
-  const values = [
-    getVillainLabel(villain),
-    phaseString,
-    multipart,
-  ].filter(Boolean);
+  const values = [getVillainLabel(villain), phaseString, multipart].filter(
+    Boolean
+  );
 
   const combinedString = values.length > 0 ? values.join(" ⬥ ") : null;
 

--- a/src/routes/combat/combat.tsx
+++ b/src/routes/combat/combat.tsx
@@ -258,7 +258,7 @@ function NpcCombatant({ npc }: NpcProps) {
 
 // Handle Attack Roll
 const rollAttackDice = (attack, attackType) => {
-  let attribute1, attribute2, extraDamage, extraPrecision;
+  let attribute1, attribute2, extraDamage, extraPrecision, type;
 
   if (attackType === "weapon") {
     // For weapon attacks
@@ -267,6 +267,7 @@ const rollAttackDice = (attack, attackType) => {
     attribute2 = attributes[att2]; 
     extraDamage = attack.weapon.damage + parseInt(attack.flatdmg) + (attack.extraDamage ? 5 : 0);
     extraPrecision = (npc.extra?.precision ? 3 : 0) + attack.weapon.prec + parseInt(attack.flathit);
+    type = attack.weapon.type;
   } else if (attackType === "spell") {
     // For spells
     const { attr1, attr2 } = attack;
@@ -274,6 +275,7 @@ const rollAttackDice = (attack, attackType) => {
     attribute2 = attributes[attr2];
     extraDamage = 0;
     extraPrecision = npc.extra?.magic ? 3 : 0;
+    type = "spell";
   } else {
     // For base attacks
     const { attr1, attr2 } = attack;
@@ -281,6 +283,7 @@ const rollAttackDice = (attack, attackType) => {
     attribute2 = attributes[attr2];
     extraDamage = attack.extraDamage ? 10 : 5;
     extraPrecision = npc.extra?.precision ? 3 : 0;
+    type = attack.type;
   }
 
   if (attribute1 === undefined || attribute2 === undefined) {
@@ -306,7 +309,12 @@ const rollAttackDice = (attack, attackType) => {
   // Calculate results
   const totalHitScore = roll1 + roll2 + extraPrecision;
   let baseDamage = Math.max(roll1, roll2);
-  const damage = baseDamage + extraDamage;
+
+  let damage = 0;
+  if (type !== "nodmg"){
+    damage = baseDamage + extraDamage;
+  };
+  
 
   // Update results
   setHitThrowResult({ totalHitScore });


### PR DESCRIPTION
- **"No Damage"** type is now selectable in the base attacks' types.
- Touched up some visual elements on the npc sheet layout to make it more faithful to the original sheet.
- Rolling for a "No Damage" type attack sets the damage to 0 in the Combat Simulator.